### PR TITLE
:sparkles: add agent stow package with global CLAUDE.md

### DIFF
--- a/agent/.claude/CLAUDE.md
+++ b/agent/.claude/CLAUDE.md
@@ -1,0 +1,119 @@
+## Preferred CLI tools
+
+Assume these are installed on my machine. **Use them first** when proposing or running terminal workflows (local dev, scripts, agents, CI that mirrors my setup)—not bare POSIX defaults unless portability or policy requires it.
+
+| Need                                          | Prefer                                                        |
+| --------------------------------------------- | ------------------------------------------------------------- |
+| Find files / trees                            | `fd`                                                          |
+| Search file contents                          | `rg` (ripgrep)                                                |
+| Fuzzy selection (files, commands, history)    | `fzf` (my setup uses `fd` as the default file source for fzf) |
+| Directory listing                             | `eza`                                                         |
+| Jump to directories by habit / recency        | `zoxide` (`z`, …)                                             |
+| View file contents with paging / highlighting | `bat`                                                         |
+| Quick command usage summaries                 | `tealdeer` (`tldr`)                                           |
+
+**Shell overrides:** In my interactive zsh, `cd` is hooked to **zoxide** (`z`) and `ls` is aliased to **eza**. For behavior that must match normal **`cd` / `ls`** (scripts, subshells, docs, CI, or when flags don't line up), use **`command cd`**, **`builtin cd`**, or **`command ls`** / **`/bin/ls`** as needed instead of the preferred tools above.
+
+**Git aliases:** Prefer **`git bat-diff`** over raw **`git diff`** when reviewing changed files with **`bat`** highlighting (when you want a readable, syntax-highlighted view of modified file contents). Use **`git merge-main`** to update the current branch from **`origin/main`** or **`origin/master`** (whichever exists)—it **requires a clean working tree** (no staged/uncommitted changes) and **prompts for confirmation** before fetching and merging; skip it for non-interactive or scripted flows unless you replicate the same steps explicitly.
+
+**Indexed / fast repo search:** Where the environment exposes **fff** (e.g. MCP server, editor integration, or project tooling), prefer **fff** for search and file discovery over long chains of generic grep/find when it reduces noise and round-trips.
+
+If something is missing in a given environment, fall back to standard tools and note it briefly.
+
+**Scope:** These preferences target everyday repo work (search, navigation, diffs). One-off diagnostics (**`dex dir`**, **`ls`** on a known path, **`head`**/**`cat`** on a single file) do not need to be forced through **`fd`**/**`rg`**/**`eza`** when that only adds friction.
+
+---
+
+## Progress tracking with dex
+
+[**dex**](https://dex.rip/) is a local-first task and milestone tracker. These dotfiles also provide **`gdex`**, a small wrapper that runs `dex` with the correct `--config` and `--storage-path` for the `greg` / `front` profiles (when `gdex` is installed/stowed on the machine).
+
+Before using dex (or `gdex`), verify dex is available:
+
+```sh
+command -v dex
+```
+
+If `dex` is not found, skip this section entirely and note it briefly—don't block the workflow.
+
+### Use `gdex`
+
+If `gdex` is available, **always use `gdex`** instead of running `dex` directly. `gdex` wraps `dex` with the correct `--config` and `--storage-path` so tasks come from the right store.
+
+```sh
+gdex <greg|front> <dex-subcommand> [args...]
+```
+
+Examples:
+
+```sh
+gdex greg list
+gdex greg create --title "Follow up"
+gdex front list
+```
+
+Wrapper help:
+
+```sh
+gdex --help
+```
+
+Full CLI reference (everything after the wrapper is just `dex`):
+
+```sh
+dex --help
+```
+
+**Choosing a profile:** Use the first argument to `gdex`:
+
+- `gdex greg …`
+- `gdex front …`
+
+**Discovering available profiles:** Enumerate from `$HOME/.dex/projects`:
+
+```sh
+command ls "$HOME/.dex/projects"
+# or every project config on disk:
+fd -t f config.toml "$HOME/.dex/projects"
+```
+
+**Runtime source of truth (any repo):** Dex profiles live only under **`$HOME/.dex/projects/`**. The git repo you have open does **not** change profile locations or names. Do not infer profile from `pwd`, from `GREG_DOTFILES_PATH`, or from whether the project is "work" vs "personal" unless explicitly tied to a profile.
+
+**Standard profile names:** **`greg`** and **`front`** are the usual dex project folder names. Their configs are:
+
+- **greg:** `$HOME/.dex/projects/greg/config.toml`
+- **front:** `$HOME/.dex/projects/front/config.toml`
+
+**`--config` means a file, not a registry:** Dex does **not** maintain a separate registry of profile names—folder names under `$HOME/.dex/projects/` are your dotfiles/stow layout, not something `dex` enumerates.
+
+**Task storage vs config (`dex dir`, `--storage-path`):** `--config` alone does not bind tasks to a particular DB. If you're debugging "missing tasks," run `dex dir` using the **same** resolved config + storage path that `gdex` uses (or just use `gdex` for the command you're running, and only drop to raw `dex` when diagnosing).
+
+**Raw `dex` fallback (debugging only):**
+
+```sh
+dex --config "$HOME/.dex/projects/greg/config.toml" --storage-path "$HOME/.dex/task-db/greg.jsonl" list
+# swap greg/front as needed
+```
+
+**Reading `dex --help` efficiently:** Scan **COMMANDS** once. If a verb is not listed, do not assume undocumented aliases unless you have other docs. **`dex config`** needs a key or **`dex config --list`** (use **`-g`** for global settings); bare **`dex config`** errors. **`dex dir`** prints the **resolved** task storage for **this** invocation (**cwd**, optional **`--config`**, optional **`--storage-path`**); it does **not** list profile folders under **`~/.dex/projects`**. Run **`dex --version`** when behavior might depend on release.
+
+**Fast path:** (1) **`ls "$HOME/.dex/projects"`** (or **`fd`**) for profile names. (2) **`dex --help`** only to confirm verbs and flags for task workflows (**list**, **create**, **`dir`**, **`config`**, **`--storage-path`**, …)—**not** to discover profile names. (3) **`dex dir`** before trusting **`list`** output; add **`--storage-path <storage-dir>`** when tasks must come from a specific store.
+
+**Dotfiles provenance (only when editing personal dotfiles):** In Greg's dotfiles repo, versioned stubs live at **`dex/.dex/projects/greg/config.toml`** (stow package **`dex`**) and, in the **front** submodule, **`front/.dex/projects/front/config.toml`** (stow package **`front`**). Task JSONL may sit under **`dex/.dex/task-db/greg.jsonl/tasks.jsonl`** and **`front/.dex/task-db/front.jsonl/tasks.jsonl`** (a **`*.jsonl`** directory next to **`tasks.jsonl`**); Greg may version those separately from the profile **`config.toml`**. **`--config`** alone does **not** imply dex reads that checkout-local **`task-db`**—confirm with **`dex dir`** and pass **`--storage-path`** to the **storage directory** (see above), not to **`tasks.jsonl`**. Agents in **other** repositories should still use **`$HOME/.dex/projects/...`** for **`--config`** unless the user explicitly asks to work from repo paths.
+
+**Repo-local `.dex/`:** Folders named `.dex/` inside some clone are **not** the default dex profile for agents. Ignore them for normal dex workflows unless the user explicitly opts into repo-local dex; prefer **`$HOME/.dex/projects/<name>/config.toml`** for every `dex --config`.
+
+**When to prompt:** At the start of any significant new task (new feature, refactor, bug investigation, multi-step build, etc.), ask once:
+
+> "Would you like to track this work in dex?"
+
+Don't ask for trivial one-offs, quick lookups, or single-file edits.
+
+**How to work with dex iteratively:**
+
+1. **Define milestones up front.** Before starting, propose a milestone breakdown based on the task scope and confirm it with the user before creating anything in dex.
+2. **Tie commits to milestones.** Each commit should map to forward progress on a milestone. Reference the relevant dex milestone or task ID in the commit message where applicable.
+3. **Run the workspace's quality checks before committing.** At each milestone boundary, look for and run whatever the project uses—tests, linting, typechecking, formatting checks, etc. Infer the right commands from the project's tooling (e.g. `package.json` scripts, `Makefile`, `pyproject.toml`, `Cargo.toml`, CI config). Prefer running `test`, `lint`, `typecheck`, and `format:check` targets (or their equivalents) rather than invoking tools directly, so the project's own configuration is respected. If checks fail: fix straightforward technical issues (type errors, lint violations, broken assertions) autonomously and re-run to confirm. If a failure involves ambiguity, a product decision, or non-trivial tradeoffs, surface it clearly with enough context for the user to make the call—don't guess or paper over it.
+4. **Always pause before staging or committing.** Show the user what files will be added (`git status`, `git bat-diff`) and get explicit confirmation before running `git add` or `git commit`. The user should be able to review changes locally before the work is locked in.
+5. **Check in at milestone boundaries.** When a milestone is complete and quality checks pass, surface a short summary of what changed and what's next, then wait for the user to confirm before moving to the next milestone.
+6. **Don't rush ahead.** Prefer smaller, reviewable commits over large batches. If unsure whether to bundle or split changes, ask.


### PR DESCRIPTION
Introduces a new stowable directory `agent/` that symlinks `agent/.claude/CLAUDE.md` → `~/.claude/CLAUDE.md` via stow.

This global Claude Code instructions file documents:
- Preferred CLI tools (fd, rg, fzf, eza, zoxide, bat, tealdeer)
- Shell override conventions for scripts/CI
- Git alias preferences (bat-diff, merge-main)
- dex/gdex progress-tracking workflow and conventions